### PR TITLE
Make package installable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # spreadsheet
 A spreadsheet engine implemented in Python.
+
+## Development
+
+Create and activate a venv:
+
+```shell
+python -m venv .venv
+. .venv/bin/activate  # on Linux
+env\Scripts\activate  # on Windows
+```
+
+Install the package and its runtime and test dependencies:
+
+```shell
+python -m pip install -e .[tests]
+```
+
+Run the tests:
+
+```shell
+python -m pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools"]
+
+[project]
+name = "spreadsheet"
+version = "0.1.0"
+dependencies = ["lark", "tabulate", "toposort"]
+
+[project.optional-dependencies]
+tests = ["pytest"]
+
+[tool.pytest.ini_options]
+python_files = ["test.py", "test_*.py"]
+pythonpath = "."


### PR DESCRIPTION
This PR adds a minimal `pyproject.toml` that allows you to run `pip install -e .[tests]` in an activated venv to install the package and all of its runtime and test dependencies into the venv.

It also configures pytest so just invoking `python -m pytest` runs the test suite without having to declare anything else on the command line.
